### PR TITLE
Adding Gradle Dependencies Sorter

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -155,7 +155,7 @@ jobs:
         run: ./gradlew checkSortDependencies
 
   androidTest:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     timeout-minutes: 55
     strategy:
       matrix:

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -155,7 +155,7 @@ jobs:
         run: ./gradlew checkSortDependencies
 
   androidTest:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 55
     strategy:
       matrix:

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -151,6 +151,9 @@ jobs:
       - name: Check badging
         run: ./gradlew :app:checkProductionReleaseBadging
 
+      - name: Dependency Sort Checks
+        run: ./gradlew checkSortDependencies
+
   androidTest:
     runs-on: ubuntu-latest
     timeout-minutes: 55

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,12 +43,18 @@ android {
 
 dependencies {
     implementation(libs.androidx.activity.compose)
-
+    implementation(libs.androidx.compose.foundation)
+    implementation(libs.androidx.compose.foundation.layout)
+    implementation(libs.androidx.compose.material.iconsExtended)
+    implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material3.adaptive)
     implementation(libs.androidx.compose.material3.adaptive.layout)
     implementation(libs.androidx.compose.material3.adaptive.navigation)
+    implementation(libs.androidx.compose.material3.navigationSuite)
     implementation(libs.androidx.compose.material3.windowSizeClass)
+    implementation(libs.androidx.compose.runtime)
     implementation(libs.androidx.compose.runtime.tracing)
+    implementation(libs.androidx.compose.ui.util)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.hilt.navigation.compose)
     implementation(libs.androidx.lifecycle.runtimeCompose)
@@ -58,28 +64,18 @@ dependencies {
     implementation(libs.coil.kt)
     implementation(libs.kotlinx.serialization.json)
 
-    implementation(libs.androidx.compose.material3)
-    implementation(libs.androidx.compose.foundation)
-    implementation(libs.androidx.compose.foundation.layout)
-    implementation(libs.androidx.compose.material.iconsExtended)
-    implementation(libs.androidx.compose.material3.adaptive)
-    implementation(libs.androidx.compose.material3.navigationSuite)
-    implementation(libs.androidx.compose.runtime)
-    implementation(libs.androidx.compose.ui.util)
-
-
     testImplementation(libs.androidx.test.rules)
-    testImplementation(libs.kotest.runner.junit5)
     testImplementation(libs.kotest.assertions.core)
     testImplementation(libs.kotest.property)
+    testImplementation(libs.kotest.runner.junit5)
 
-    androidTestImplementation(libs.androidx.test.core)
-    androidTestImplementation(libs.androidx.test.runner)
-    androidTestImplementation(libs.kotlinx.coroutines.test)
-    androidTestImplementation(libs.androidx.test.espresso.core)
     androidTestImplementation(libs.androidx.compose.ui.test)
+    androidTestImplementation(libs.androidx.test.core)
+    androidTestImplementation(libs.androidx.test.espresso.core)
+    androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.hilt.android.testing)
     androidTestImplementation(libs.kotlin.test)
+    androidTestImplementation(libs.kotlinx.coroutines.test)
 }
 dependencyGuard {
     configuration("productionReleaseRuntimeClasspath")

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -17,6 +17,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                 apply("org.jetbrains.kotlin.android")
                 apply("framework.android.ktlint")
                 apply("com.dropbox.dependency-guard")
+                apply("com.squareup.sort-dependencies")
             }
 
             extensions.configure<ApplicationExtension> {

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -16,6 +16,7 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
                 apply("com.android.library")
                 apply("org.jetbrains.kotlin.android")
                 apply("framework.android.ktlint")
+                apply("com.squareup.sort-dependencies")
             }
 
             extensions.configure<LibraryExtension> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.kotliner) apply false
     alias(libs.plugins.dependencyGuard) apply false
+    alias(libs.plugins.square.sort.dependencies) apply false
 }
 
 

--- a/git-hooks/pre-commit-unix.sh
+++ b/git-hooks/pre-commit-unix.sh
@@ -23,4 +23,21 @@ echo "$CHANGED_FILES" | while read -r file; do
 done
 
 ######## KTLINT-GRADLE HOOK END ########
+
+echo "Sorting dependencies."
+
+./gradlew sortDependencies
+
+echo "Completed sorting dependencies."
+
+# Look for any changed files that are gradle, gradle.kts, or toml and git add them.
+# This ensures any files changed by sortDependencies get added to this git commit.
+CHANGED_VERSION_FILES="$(git --no-pager diff --name-status --no-color --cached | awk '$1 != "D" && $2 ~ /\.gradle|\.toml|\.gradle.kts/ { print $2}')"
+
+echo "$CHANGED_VERSION_FILES" | while read -r file; do
+    if [ -f $file ]; then
+        git add $file
+    fi
+done
+
 echo "Completed pre-commit hook."

--- a/git-hooks/pre-commit-windows.sh
+++ b/git-hooks/pre-commit-windows.sh
@@ -23,4 +23,21 @@ echo "$CHANGED_FILES" | while read -r file; do
 done
 
 ######## KTLINT-GRADLE HOOK END ########
+
+echo "Sorting dependencies."
+
+./gradlew sortDependencies
+
+echo "Completed sorting dependencies."
+
+# Look for any changed files that are gradle, gradle.kts, or toml and git add them.
+# This ensures any files changed by sortDependencies get added to this git commit.
+CHANGED_VERSION_FILES="$(git --no-pager diff --name-status --no-color --cached | awk '$1 != "D" && $2 ~ /\.gradle|\.toml|\.gradle.kts/ { print $2}')"
+
+echo "$CHANGED_VERSION_FILES" | while read -r file; do
+    if [ -f $file ]; then
+        git add $file
+    fi
+done
+
 echo "Completed pre-commit hook."

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ androidxWindowManager = "1.3.0"
 androidxWork = "2.10.0"
 coil = "2.7.0"
 dependencyGuard = "0.5.0"
+sortDependencies = "0.13"
 firebaseBom = "33.7.0"
 firebaseCrashlyticsPlugin = "3.0.2"
 firebasePerfPlugin = "1.4.2"
@@ -172,7 +173,7 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotliner = { id = "org.jmailen.kotlinter", version.ref = "kotlinter" }
 dependencyGuard = { id = "com.dropbox.dependency-guard", version.ref = "dependencyGuard" }
-
+square-sort-dependencies = { id = "com.squareup.sort-dependencies", version.ref = "sortDependencies" }
 
 
 # Plugins defined by this project


### PR DESCRIPTION
Just learned about this Gradle plugin on Twitter that helps sort dependencies. Sounds kind of opinionated, but given this template is largely about developer tooling something like this might be nice. Will probably make a test PR and see how it feels.

Docs here: https://github.com/square/gradle-dependencies-sorter

Close #10