### PR TITLE
Add specification pattern classes

### DIFF
--- a/core/domain/src/main/kotlin/ir/vahid/framework/core/domain/specification/AndSpecification.kt
+++ b/core/domain/src/main/kotlin/ir/vahid/framework/core/domain/specification/AndSpecification.kt
@@ -1,0 +1,10 @@
+package ir.vahid.framework.core.domain.specification
+
+class AndSpecification<T>(
+    private val left: ISpecification<T>,
+    private val right: ISpecification<T>,
+) : ISpecification<T> {
+    override fun isSatisfiedBy(candidate: T): Boolean {
+        return left.isSatisfiedBy(candidate) && right.isSatisfiedBy(candidate)
+    }
+}

--- a/core/domain/src/main/kotlin/ir/vahid/framework/core/domain/specification/CompositeSpecification.kt
+++ b/core/domain/src/main/kotlin/ir/vahid/framework/core/domain/specification/CompositeSpecification.kt
@@ -1,0 +1,18 @@
+package ir.vahid.framework.core.domain.specification
+
+abstract class CompositeSpecification<T> : ISpecification<T> {
+    abstract override fun isSatisfiedBy(candidate: T): Boolean
+    fun and(
+        left: ISpecification<T>,
+        right: ISpecification<T>,
+    ) = AndSpecification(left, right)
+
+    fun or(
+        left: ISpecification<T>,
+        right: ISpecification<T>,
+    ) = OrSpecification(left, right)
+
+    fun not(
+        target: ISpecification<T>,
+    ) = NotSpecification(target)
+}

--- a/core/domain/src/main/kotlin/ir/vahid/framework/core/domain/specification/ISpecification.kt
+++ b/core/domain/src/main/kotlin/ir/vahid/framework/core/domain/specification/ISpecification.kt
@@ -1,0 +1,5 @@
+package ir.vahid.framework.core.domain.specification
+
+interface ISpecification<T> {
+    fun isSatisfiedBy(candidate: T): Boolean
+}

--- a/core/domain/src/main/kotlin/ir/vahid/framework/core/domain/specification/NotSpecification.kt
+++ b/core/domain/src/main/kotlin/ir/vahid/framework/core/domain/specification/NotSpecification.kt
@@ -1,0 +1,9 @@
+package ir.vahid.framework.core.domain.specification
+
+class NotSpecification<T> (
+    private val target: ISpecification<T>
+): ISpecification<T> {
+    override fun isSatisfiedBy(candidate: T): Boolean {
+        return !target.isSatisfiedBy(candidate)
+    }
+}

--- a/core/domain/src/main/kotlin/ir/vahid/framework/core/domain/specification/OrSpecification.kt
+++ b/core/domain/src/main/kotlin/ir/vahid/framework/core/domain/specification/OrSpecification.kt
@@ -1,0 +1,10 @@
+package ir.vahid.framework.core.domain.specification
+
+class OrSpecification<T>(
+    private val left: ISpecification<T>,
+    private val right: ISpecification<T>,
+) : ISpecification<T> {
+    override fun isSatisfiedBy(candidate: T): Boolean {
+        return left.isSatisfiedBy(candidate) || right.isSatisfiedBy(candidate)
+    }
+}


### PR DESCRIPTION
This commit introduces the following classes to implement the specification pattern:
- `ISpecification` interface
- `CompositeSpecification` abstract class
- `AndSpecification`
- `OrSpecification`
- `NotSpecification`