### PR TITLE
Update KSP and apply it as a plugin

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     compileOnly(libs.compose.gradlePlugin)
     compileOnly(libs.kotlin.gradlePlugin)
     compileOnly(libs.detekt.gradlePlugin)
+    compileOnly(libs.ksp.gradlePlugin)
     implementation(libs.truth)
 }
 

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,5 +1,6 @@
 pluginManagement {
     repositories {
+        maven("https://maven.myket.ir")
         gradlePluginPortal()
         google()
     }
@@ -8,6 +9,7 @@ pluginManagement {
 
 dependencyResolutionManagement {
     repositories {
+        maven("https://maven.myket.ir")
         google {
             content {
                 includeGroupByRegex("com\\.android.*")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,7 @@ plugins {
     alias(libs.plugins.dependencyGuard) apply false
     alias(libs.plugins.square.sort.dependencies) apply false
     alias(libs.plugins.detekt) apply true
+    alias(libs.plugins.ksp) apply false
 }
 
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,7 +46,7 @@ kotlinter = "5.0.1"
 kotlinxCoroutines = "1.10.1"
 kotlinxDatetime = "0.6.2"
 kotlinxSerializationJson = "1.8.1"
-ksp = "2.1.0-1.0.29"
+ksp = "2.1.20-1.0.32"
 moduleGraph = "2.7.1"
 okhttp = "4.12.0"
 protobuf = "4.30.2"
@@ -165,6 +165,7 @@ android-tools-common = { group = "com.android.tools", name = "common", version.r
 androidx-material3-android = { group = "androidx.compose.material3", name = "material3-android", version.ref = "material3Android" }
 detekt-gradlePlugin = { group = "io.gitlab.arturbosch.detekt", name = "detekt-gradle-plugin", version.ref = "detekt" }
 detekt-formatting = { group = "io.gitlab.arturbosch.detekt", name = "detekt-formatting", version.ref = "detekt" }
+ksp-gradlePlugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
@@ -175,6 +176,7 @@ dependencyGuard = { id = "com.dropbox.dependency-guard", version.ref = "dependen
 square-sort-dependencies = { id = "com.squareup.sort-dependencies", version.ref = "sortDependencies" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 roborazzi = { id = "io.github.takahirom.roborazzi", version.ref = "roborazzi" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 
 
 


### PR DESCRIPTION
```
Update KSP and apply it as a plugin

- Update KSP version from 2.1.0-1.0.29 to 2.1.20-1.0.32.
- Apply KSP plugin in `build.gradle.kts`.
- Add KSP Gradle plugin as compile-only dependency to `build-logic` project.
- Add "https://maven.myket.ir" maven repository for pluginManagement and dependencyResolutionManagement.
```

close #105